### PR TITLE
Relax the validation for the metadata.author field

### DIFF
--- a/client_utils/models/api/rwpm_audiobook.py
+++ b/client_utils/models/api/rwpm_audiobook.py
@@ -57,7 +57,7 @@ class ManifestMetadata(BaseModel):
     object_type: str = Field(..., alias="@type")
     identifier: str
     title: str
-    author: str
+    author: str | list[str] | None = None
     publisher: str
     published: datetime.datetime
     language: str


### PR DESCRIPTION
Going through the downloaded manifests the validation on author was causing a lot of `ValidationErrors`. Author isn't a required field, so relaxed the validation there.