### PR TITLE
Handle zero length chapters

### DIFF
--- a/client_utils/models/api/rwpm_audiobook.py
+++ b/client_utils/models/api/rwpm_audiobook.py
@@ -22,9 +22,6 @@ class ToCEntry(BaseModel):
     track_href: str = ""
     track_offset: int = 0
 
-    # Unique identifier for this ToCEntry.
-    internal_id: UUID = Field(default_factory=uuid4)
-
     @model_validator(mode="after")
     def computed_values(self) -> Self:
         self.track_href, offset = self.href.split("#t=")

--- a/client_utils/models/api/rwpm_audiobook.py
+++ b/client_utils/models/api/rwpm_audiobook.py
@@ -4,7 +4,6 @@ import datetime
 import sys
 from collections.abc import Generator, Sequence
 from functools import cached_property
-from uuid import UUID, uuid4
 
 from pydantic import BaseModel, Field, model_validator
 

--- a/client_utils/models/api/rwpm_audiobook.py
+++ b/client_utils/models/api/rwpm_audiobook.py
@@ -4,6 +4,7 @@ import datetime
 import sys
 from collections.abc import Generator, Sequence
 from functools import cached_property
+from uuid import UUID, uuid4
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -20,6 +21,9 @@ class ToCEntry(BaseModel):
     # Computed properties.
     track_href: str = ""
     track_offset: int = 0
+
+    # Unique identifier for this ToCEntry.
+    internal_id: UUID = Field(default_factory=uuid4)
 
     @model_validator(mode="after")
     def computed_values(self) -> Self:

--- a/client_utils/models/internal/rwpm_audio/audiobook.py
+++ b/client_utils/models/internal/rwpm_audio/audiobook.py
@@ -48,9 +48,9 @@ class Audiobook:
     manifest: Manifest
 
     @cached_property
-    def segments_by_toc(self) -> dict[UUID, Sequence[AudioSegment]]:
+    def segments_by_toc_id(self) -> dict[int, Sequence[AudioSegment]]:
         return {
-            toc_segments.toc_entry.internal_id: toc_segments.audio_segments
+            id(toc_segments.toc_entry): toc_segments.audio_segments
             for toc_segments in audio_segments_for_all_toc_entries(
                 all_toc_entries=self.manifest.toc_in_playback_order,
                 all_tracks=self.manifest.reading_order,
@@ -72,13 +72,13 @@ class Audiobook:
                 EnhancedToCEntry(
                     depth=depth,
                     duration=sum(
-                        segment.duration for segment in self.segments_by_toc[entry.internal_id]
+                        segment.duration for segment in self.segments_by_toc_id[id(entry)]
                     ),
                     actual_duration=sum(
                         segment.actual_duration
-                        for segment in self.segments_by_toc[entry.internal_id]
+                        for segment in self.segments_by_toc_id[id(entry)]
                     ),
-                    audio_segments=self.segments_by_toc[entry.internal_id],
+                    audio_segments=self.segments_by_toc_id[id(entry)],
                     sub_entries=self.generate_enhanced_toc(
                         toc=entry.children, depth=depth + 1
                     ),

--- a/client_utils/models/internal/rwpm_audio/audiobook.py
+++ b/client_utils/models/internal/rwpm_audio/audiobook.py
@@ -5,7 +5,6 @@ from collections.abc import Generator, Sequence
 from dataclasses import dataclass
 from functools import cached_property
 from pathlib import Path
-from uuid import UUID
 
 from mutagen.mp3 import MP3
 
@@ -72,7 +71,8 @@ class Audiobook:
                 EnhancedToCEntry(
                     depth=depth,
                     duration=sum(
-                        segment.duration for segment in self.segments_by_toc_id[id(entry)]
+                        segment.duration
+                        for segment in self.segments_by_toc_id[id(entry)]
                     ),
                     actual_duration=sum(
                         segment.actual_duration

--- a/client_utils/models/internal/rwpm_audio/audiobook.py
+++ b/client_utils/models/internal/rwpm_audio/audiobook.py
@@ -5,6 +5,7 @@ from collections.abc import Generator, Sequence
 from dataclasses import dataclass
 from functools import cached_property
 from pathlib import Path
+from uuid import UUID
 
 from mutagen.mp3 import MP3
 
@@ -47,9 +48,9 @@ class Audiobook:
     manifest: Manifest
 
     @cached_property
-    def segments_by_toc(self) -> dict[str, Sequence[AudioSegment]]:
+    def segments_by_toc(self) -> dict[UUID, Sequence[AudioSegment]]:
         return {
-            toc_segments.toc_entry.href: toc_segments.audio_segments
+            toc_segments.toc_entry.internal_id: toc_segments.audio_segments
             for toc_segments in audio_segments_for_all_toc_entries(
                 all_toc_entries=self.manifest.toc_in_playback_order,
                 all_tracks=self.manifest.reading_order,
@@ -71,13 +72,13 @@ class Audiobook:
                 EnhancedToCEntry(
                     depth=depth,
                     duration=sum(
-                        segment.duration for segment in self.segments_by_toc[entry.href]
+                        segment.duration for segment in self.segments_by_toc[entry.internal_id]
                     ),
                     actual_duration=sum(
                         segment.actual_duration
-                        for segment in self.segments_by_toc[entry.href]
+                        for segment in self.segments_by_toc[entry.internal_id]
                     ),
-                    audio_segments=self.segments_by_toc[entry.href],
+                    audio_segments=self.segments_by_toc[entry.internal_id],
                     sub_entries=self.generate_enhanced_toc(
                         toc=entry.children, depth=depth + 1
                     ),


### PR DESCRIPTION
Since `href` in the `toc` isn't necessarily unique, right now `segments_by_toc` is not able to handle zero length chapters. This PR renames `segments_by_toc` to `segments_by_toc_id` and uses `id(entry)` as the key, so we get the correct information for 0 length chapters.