### PR TITLE
Factor out CLI runner.

### DIFF
--- a/client_utils/cli/download_lcp_manifest.py
+++ b/client_utils/cli/download_lcp_manifest.py
@@ -16,13 +16,14 @@ from client_utils.models.api.readium_lcp_license_v1 import LCPLicenseDocument
 from client_utils.utils.http.async_client import HTTPXAsyncClient
 from client_utils.utils.http.auth_token import BaseAuthorizationToken, BasicAuthToken
 from client_utils.utils.http.streaming import streaming_fetch_with_progress
+from client_utils.utils.typer import run_typer_app_as_main
 
 STDOUT = 1
 app = typer.Typer()
 
 
 def main() -> None:
-    app(prog_name="download-lcp-audio-manifest")
+    run_typer_app_as_main(app, prog_name="download-lcp-audio-manifest")
 
 
 @app.command()

--- a/client_utils/cli/patron_bookshelf.py
+++ b/client_utils/cli/patron_bookshelf.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import json
-import traceback
 
 import typer
 
@@ -10,20 +9,16 @@ from client_utils.constants import DEFAULT_REGISTRY_URL
 from client_utils.models.internal.bookshelf import print_bookshelf_summary
 from client_utils.roles.patron import authenticate
 from client_utils.utils.http.async_client import HTTPXAsyncClient
+from client_utils.utils.typer import run_typer_app_as_main
 
-_app = typer.Typer(rich_markup_mode="rich")
+app = typer.Typer(rich_markup_mode="rich")
 
 
 def main():
-    try:
-        _app()
-    except typer.Exit:
-        pass
-    except Exception:
-        traceback.print_exc()
+    run_typer_app_as_main(app)
 
 
-@_app.command(
+@app.command(
     help="Print a patron's bookshelf.",
     epilog="[red]Use options from only one of the three numbered option groups.[/red]",
     no_args_is_help=True,

--- a/client_utils/cli/summarize_rwpm_audio_manifest.py
+++ b/client_utils/cli/summarize_rwpm_audio_manifest.py
@@ -9,12 +9,13 @@ import typer
 
 from client_utils.models.internal.rwpm_audio.audiobook import Audiobook
 from client_utils.utils.datetime import seconds_to_hms
+from client_utils.utils.typer import run_typer_app_as_main
 
 app = typer.Typer()
 
 
 def main() -> None:
-    app(prog_name="summarize-manifest")
+    run_typer_app_as_main(app, prog_name="summarize-manifest")
 
 
 @app.command()
@@ -52,9 +53,14 @@ def text_with_time_delta(
 ) -> str:
     """Append a time delta in seconds and hours:minutes:seconds to some label text.
 
+    An optional second delta can be appended to the time delta.
+
     :param text: The label text.
     :param delta_secs: The duration in seconds.
     :param delta_label: (Optional) Label characterizing the time delta.
+    :param delta_suffix: (Optional) Another label characterizing `delta_secs`.
+    :param second_delta: (Optional) second duration in seconds.
+    :param second_delta_suffix: (Optional) Label characterizing `second_delta`.
     :return: The label text with the duration appended.
     """
     delta_suffix = delta_suffix if second_delta else None

--- a/client_utils/cli/validate_manifests.py
+++ b/client_utils/cli/validate_manifests.py
@@ -8,12 +8,13 @@ from pydantic import ValidationError
 from client_utils.cli.summarize_rwpm_audio_manifest import text_with_time_delta
 from client_utils.models.internal.rwpm_audio.audiobook import Audiobook
 from client_utils.utils.datetime import seconds_to_hms
+from client_utils.utils.typer import run_typer_app_as_main
 
 app = typer.Typer()
 
 
 def main() -> None:
-    app(prog_name="validate-audiobook-manifests")
+    run_typer_app_as_main(app, prog_name="validate-audiobook-manifests")
 
 
 @app.command()

--- a/client_utils/models/api/opds2.py
+++ b/client_utils/models/api/opds2.py
@@ -1,7 +1,7 @@
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from typing import Any, TypeVar
 
-from pydantic import Field, HttpUrl
+from pydantic import Field
 
 from client_utils.constants import (
     OPDS_ACQ_OPEN_ACCESS_REL,
@@ -25,7 +25,7 @@ For the purpose of validating an OPDS 2.0 catalog, use the following JSON Schema
 
 
 class OPDS2Link(ApiBaseModel):
-    href: HttpUrl | str
+    href: str
     rel: str | list[str]
     type: str | None = None
     title: str | None = None

--- a/client_utils/utils/typer.py
+++ b/client_utils/utils/typer.py
@@ -1,0 +1,23 @@
+#
+# Helpers for the `typer` package.
+#
+import sys
+import traceback
+from typing import Any
+
+import typer
+
+
+def run_typer_app_as_main(app, *args, **kwargs) -> Any | None:
+    """Run a typer app as the main function.
+
+    Catch any uncaught exceptions and print them to stderr.
+    """
+    try:
+        return app(*args, **kwargs)
+    except typer.Exit as e:
+        sys.exit(e.exit_code)
+    except Exception:
+        traceback.print_exc()
+
+    return None


### PR DESCRIPTION
- Factors out some CLI runner code, so all the scripts can use the same convention.
- Simplifies a model to resolve a `mypy` issue.